### PR TITLE
Added missing namespace qualifier for the move function in the flat_m…

### DIFF
--- a/include/rustfp/flat_map.h
+++ b/include/rustfp/flat_map.h
@@ -132,7 +132,7 @@ auto FlatMap<Self, F>::next() -> Option<Item> {
             continue;
         }
 
-        sub_self_opt = Some(move(sub_self));
+        sub_self_opt = Some(std::move(sub_self));
 
         // success case
         return std::move(next_opt);


### PR DESCRIPTION
…ap.h